### PR TITLE
Add support for new models with new protocol. 

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -10,5 +10,5 @@ This module will connect to a Panasonic TV TH series, such as the TH-86CQ1W, TH-
 * Input Select
 * View Mode
 
-New models (such as the TH-49CQE1W), require and updated communication protocol, if using one of these new models you will also get the power status reported as a variable. 
+New models (such as the TH-49CQE1W), require an updated communication protocol, if using one of these new models you will also get the power status reported as a variable. 
 

--- a/HELP.md
+++ b/HELP.md
@@ -1,6 +1,6 @@
 ## Panasonic TV TH-Series
 
-This module will connect to a Panasonic TV TH series, such as the TH-86CQ1W, TH-75CQ1W, TH-65CQ1W, TH-55CQ1W, TH-50CQ1, and TH-43CQ1W models.
+This module will connect to a Panasonic TV TH series, such as the TH-86CQ1W, TH-75CQ1W, TH-65CQ1W, TH-55CQ1W, TH-50CQ1, TH-43CQ1W and TH-49CQE1W models.
 
 **Available commands**
 * Power On
@@ -9,3 +9,6 @@ This module will connect to a Panasonic TV TH series, such as the TH-86CQ1W, TH-
 * Mute
 * Input Select
 * View Mode
+
+New models (such as the TH-49CQE1W), require and updated communication protocol, if using one of these new models you will also get the power status reported as a variable. 
+

--- a/index.js
+++ b/index.js
@@ -345,6 +345,24 @@ instance.prototype.action = function (action) {
       console.log(cmd)
     } else {
       debug("Socket not connected :(");
+      }
+    }
+  } else {
+    cmd = action.action
+    if (action.options.action !== undefined) {
+      cmd = cmd + ":" + action.options.action
+    }
+    cmd = `${self.hash}00${cmd}\r`
+
+    if (cmd !== undefined) {
+      debug("sending ", cmd, "to", self.config.host);
+
+      if (self.socket !== undefined && self.socket.connected) {
+        self.socket.write(cmd);
+        console.log(cmd)
+      } else {
+        debug("Socket not connected :(");
+      }
     }
   }
 };

--- a/index.js
+++ b/index.js
@@ -19,14 +19,10 @@ function instance(system, id, config) {
 
 instance.prototype.updateConfig = function (config) {
   var self = this;
-  self.init_presets();
-
-  if (self.socket !== undefined) {
-    self.socket.destroy();
-    delete self.socket;
-  }
-
   self.config = config;
+  self.setProtocol()
+  self.init_presets();
+  self.init_variables()
   self.init_tcp();
 };
 

--- a/index.js
+++ b/index.js
@@ -93,6 +93,16 @@ instance.prototype.init_tcp = function () {
         let seed = String(d).split(" ")[2].trim();
         self.hash = crypto.createHash('md5').update(self.config.user + ":" + self.config.pass + ":" + seed).digest("hex");
       }
+
+      if (String(d).trim() === "000") {
+        debug("TV is Off")
+        self.setVariable('powerState', "off")
+      }
+
+      if (String(d).trim() === "001") {
+        debug("TV is On")
+        self.setVariable('powerState', "on")
+      }
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -291,5 +291,31 @@ instance.prototype.action = function (action) {
   }
 };
 
+instance.prototype.setProtocol = function () {
+  var self = this
+  self.protocol = this.isNewProtocol() ? 'new' : 'old';
+  debug("Protocol:", self.protocol);
+}
+
+instance.prototype.isNewProtocol = function () {
+  var self = this
+  debug("Checking protocol version");
+  switch (self.config.product) {
+    case "TH-86CQ1W":
+      return false;
+    case "TH-75CQ1W":
+      return false;
+    case "TH-65CQ1W":
+      return false;
+    case "TH-55CQ1W":
+      return false;
+    case "TH-43CQ1W":
+      return false;
+    case "TH-49CQE1W":
+      return true;
+    default:
+      false
+  }
+}
 instance_skel.extendedBy(instance);
 exports = module.exports = instance;

--- a/index.js
+++ b/index.js
@@ -88,6 +88,11 @@ instance.prototype.init_tcp = function () {
           console.log("Response: " + self.config.pass);
         }
       }
+      if (String(d).match(/NTCONTROL\s1\s\w+/)) {
+        debug("New comanand structure")
+        let seed = String(d).split(" ")[2].trim();
+        self.hash = crypto.createHash('md5').update(self.config.user + ":" + self.config.pass + ":" + seed).digest("hex");
+      }
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -31,7 +31,9 @@ instance.prototype.init = function () {
 
   debug = self.debug;
   log = self.log;
+  self.setProtocol()
   self.init_presets();
+  self.init_variables()
   self.init_tcp();
 };
 

--- a/index.js
+++ b/index.js
@@ -28,7 +28,6 @@ instance.prototype.updateConfig = function (config) {
 
 instance.prototype.init = function () {
   var self = this;
-
   debug = self.debug;
   log = self.log;
   self.setProtocol()
@@ -155,8 +154,7 @@ instance.prototype.init_tcp = function () {
 instance.prototype.config_fields = function () {
   var self = this;
 
-  return [
-    {
+  return [{
       type: "textinput",
       id: "host",
       label: "Target IP",
@@ -184,7 +182,7 @@ instance.prototype.config_fields = function () {
       label: "Password",
       width: 4,
       default: "@Panasonic",
-    },
+    }
   ];
 };
 
@@ -215,65 +213,56 @@ instance.prototype.destroy = function () {
   debug("destroy", self.id);
 };
 
-instance.prototype.CHOICES_IMS = [
-  { id: "HM1", label: "HDMI 1" },
-  { id: "HM2", label: "HDMI 2" },
-  { id: "PC1", label: "PC" },
-  { id: "UD1", label: "USB" },
+instance.prototype.CHOICES_IMS = [{
+    id: "HM1",
+    label: "HDMI 1"
+  },
+  {
+    id: "HM2",
+    label: "HDMI 2"
+  },
+  {
+    id: "PC1",
+    label: "PC"
+  },
+  {
+    id: "UD1",
+    label: "USB"
+  },
 ];
 
-instance.prototype.CHOICES_DAM = [
-  { id: "FULL", label: "Full" },
-  { id: "NORM", label: "Normal" },
-  { id: "NATV", label: "Native" },
-  { id: "ZOOM", label: "Zoom" },
+instance.prototype.CHOICES_DAM = [{
+    id: "FULL",
+    label: "Full"
+  },
+  {
+    id: "NORM",
+    label: "Normal"
+  },
+  {
+    id: "NATV",
+    label: "Native"
+  },
+  {
+    id: "ZOOM",
+    label: "Zoom"
+  },
 ];
 
-instance.prototype.CHOICES_AMT = [
-  { id: "0", label: "Mute off" },
-  { id: "1", label: "Mute on" },
+instance.prototype.CHOICES_AMT = [{
+    id: "0",
+    label: "Mute off"
+  },
+  {
+    id: "1",
+    label: "Mute on"
+  },
 ];
 
 instance.prototype.init_presets = function () {
   var self = this;
   var presets = [];
   var pstSize = "18";
-
-  /*	presets.push({
-		category: 'Inputs',
-		label: 'TV',
-		bank: {
-			style: 'text',
-			text: 'TV',
-			size: pstSize,
-			color: '16777215',
-			bgcolor: 0
-		},
-		actions: [{
-			action: 'input_tv',
-		}]
-	});
-
-	for (var input in self.CHOICES_INPUTS) {
-		presets.push({
-			category: 'Inputs',
-			label: self.CHOICES_INPUTS[input].label,
-			bank: {
-				style: 'text',
-				text: self.CHOICES_INPUTS[input].label,
-				size: pstSize,
-				color: '16777215',
-				bgcolor: 0
-			},
-			actions: [{
-				action: 'input',
-				options: {
-					action: self.CHOICES_INPUTS[input].id,
-				}
-			}]
-		});
-	}
-	*/
   self.setPresetDefinitions(presets);
 };
 
@@ -281,60 +270,56 @@ instance.prototype.actions = function (system) {
   var self = this;
 
   self.setActions({
-    PON: { label: "Power ON" },
-    POF: { label: "Power OFF" },
+    PON: {
+      label: "Power ON"
+    },
+    POF: {
+      label: "Power OFF"
+    },
     AVL: {
       label: "Set Volume",
-      options: [
-        {
-          type: "number",
-          id: "action",
-          label: "Volume 0-100%",
-          min: 1,
-          max: 100,
-          default: 50,
-          required: true,
-          range: false,
-          regex: self.REGEX_NUMBER,
-        },
-      ],
-		},
-		AMT: {
+      options: [{
+        type: "number",
+        id: "action",
+        label: "Volume 0-100%",
+        min: 1,
+        max: 100,
+        default: 50,
+        required: true,
+        range: false,
+        regex: self.REGEX_NUMBER,
+      }, ],
+    },
+    AMT: {
       label: "Mute",
-      options: [
-        {
-          type: "dropdown",
-          id: "action",
-          label: "Input",
-          default: "1",
-          choices: self.CHOICES_AMT
-        },
-      ],
+      options: [{
+        type: "dropdown",
+        id: "action",
+        label: "Input",
+        default: "1",
+        choices: self.CHOICES_AMT
+      }, ],
     },
     IMS: {
       label: "Input Select",
-      options: [
-        {
-          type: "dropdown",
-          id: "action",
-          label: "Input",
-          default: "IM1",
-          choices: self.CHOICES_IMS,
-        },
-      ],
+      options: [{
+        type: "dropdown",
+        id: "action",
+        label: "Input",
+        default: "IM1",
+        choices: self.CHOICES_IMS,
+      }, ],
     },
 
     DAM: {
       label: "View Mode",
-      options: [
-        {
-          type: "dropdown",
-          id: "action",
-          label: "Mode:",
-          default: "1",
-          choices: self.CHOICES_DAM,
-        },
-      ],
+      options: [{
+        type: "dropdown",
+        id: "action",
+        label: "Mode:",
+        default: "1",
+        choices: self.CHOICES_DAM,
+      }, ],
     },
   });
 };
@@ -342,20 +327,22 @@ instance.prototype.actions = function (system) {
 instance.prototype.action = function (action) {
   var self = this;
   var cmd;
-	console.log("XX", action);
+  console.log("XX", action);
+  if (self.protocol === "old") {
 
-	cmd = "\x02" + action.action
-	if (action.options.action !== undefined) {
-		cmd = cmd + ":" + action.options.action
-	}
-	cmd = cmd + "\x03\n"
+  }
+  cmd = "\x02" + action.action
+  if (action.options.action !== undefined) {
+    cmd = cmd + ":" + action.options.action
+  }
+  cmd = cmd + "\x03\n"
 
   if (cmd !== undefined) {
     debug("sending ", cmd, "to", self.config.host);
 
     if (self.socket !== undefined && self.socket.connected) {
-			self.socket.send(Buffer.from(cmd));
-			console.log(cmd)
+      self.socket.send(Buffer.from(cmd));
+      console.log(cmd)
     } else {
       debug("Socket not connected :(");
     }

--- a/index.js
+++ b/index.js
@@ -362,6 +362,16 @@ instance.prototype.action = function (action) {
   }
 };
 
+instance.prototype.checkPowerStatus = function () {
+  var self = this
+  if (self.socket !== undefined && self.socket.connected && self.protocol === "new") {
+    debug("Checking power state");
+    self.socket.write(self.hash + "00QPW" + "\r");
+  } else {
+    debug("Socket not connected :(");
+  }
+}
+
 instance.prototype.setProtocol = function () {
   var self = this
   self.protocol = this.isNewProtocol() ? 'new' : 'old';

--- a/index.js
+++ b/index.js
@@ -90,6 +90,25 @@ instance.prototype.init_tcp = function () {
       }
     });
   }
+
+  self.socket.on('end', function () {
+    self.connected = false
+    if (self.lastStatus != self.STATUS_ERROR + ';Disc') {
+      self.log('error', 'Display Disconnected')
+      self.status(self.STATUS_ERROR, 'Disconnected')
+      self.lastStatus = self.STATUS_ERROR + ';Disc'
+    }
+    // set timer to retry connection in 30 secs
+    if (self.socketTimer) {
+      clearInterval(self.socketTimer)
+      delete self.socketTimer
+    }
+    self.socketTimer = setInterval(function () {
+      self.status(self.STATUS_ERROR, 'Retrying connection')
+      self.init_tcp()
+    }, 30000)
+    debug('Disconnected')
+  })
 };
 
 // Return config fields for web config

--- a/index.js
+++ b/index.js
@@ -129,6 +129,18 @@ instance.prototype.config_fields = function () {
   ];
 };
 
+instance.prototype.init_variables = function () {
+  var self = this
+  var variables = []
+  if (self.protocol === "new") {
+    variables.push({
+      label: 'TV Power Status',
+      name: 'powerState',
+    })
+
+    self.setVariableDefinitions(variables)
+  }
+}
 // When module gets deleted
 instance.prototype.destroy = function () {
   var self = this;

--- a/index.js
+++ b/index.js
@@ -98,6 +98,7 @@ instance.prototype.init_tcp = function () {
     self.socket.on("data", function (d) {
       if (cmd_debug === true) {
         console.log("Recv:", d);
+        console.log(String(d))
       }
 
       if (String(d) === "Login:") {

--- a/index.js
+++ b/index.js
@@ -388,5 +388,21 @@ instance.prototype.isNewProtocol = function () {
       false
   }
 }
+
+
+instance.prototype.poll = function () {
+  var self = this
+  debug("Polling");
+  // // var checkHours = false
+
+  // re-connect?
+  if (!self.socket.connected) {
+    self.init_tcp()
+    return
+  }
+  self.checkPowerStatus()
+}
+
+
 instance_skel.extendedBy(instance);
 exports = module.exports = instance;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var tcp = require("../../tcp");
 var instance_skel = require("../../instance_skel");
+var crypto = require('crypto');
 var debug;
 var log;
 var cmd_debug = true;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
 		"TH-65CQ1W",
 		"TH-55CQ1W",
 		"TH-50CQ1W",
-		"TH-43CQ1W"
+		"TH-43CQ1W",
+		"TH-49CQE1W"
 	],
 	"shortname": "TV",
 	"homepage": "https://github.com/bitfocus/companion-module-panasonic-tv-th#readme",


### PR DESCRIPTION
Newer models of TV with the newer (rubbish) UI/OS require a more complicated communication setup, with hashing of a string that is provided when opening the socket to authenticate. This adds support for that, it will automatically switch to that setup when it detects the selected model as the TH-49CQE1W. I would expect this to work for other new models too, but they would need to be added to be identified.